### PR TITLE
Removes reference to old curriculum schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Practice Challenge: WOOF WOOF
 
-You may remember this from Mod 3!
+You may remember this from Phase 1!
 
 There's less base code here - use what you know about React to make this
-application work like your Mod 3 one did.
+application work like your Phase 1 one did.
 
 Think about what components you'll need, what you need to keep in state. Draw
 out a quick sketch if it helps! There's a bit of starter code in `src/App.js`.


### PR DESCRIPTION
Closes #1 
Thanks for flagging, @amiefoster! We went ahead and changed the reference from phase 3 to phase 1. Nice catch! 
Please note this probably won't be reflected in your Canvas lesson, but the change will be in Github, as well as in Canvas for future students. 
Thanks again!